### PR TITLE
Integer Key of XML tag caused error. Converted key to string

### DIFF
--- a/JsonToXML.py
+++ b/JsonToXML.py
@@ -12,7 +12,7 @@ def _addSubList(root,key1,data):
         if type(data[key]) in (list,):
             _addSubList(root,data[key])
             continue
-        ET.SubElement(root,key).text=str(data[key])
+        ET.SubElement(root,str(key)).text=str(data[key])
         
 
 def _addSubDict(root,data):
@@ -24,7 +24,7 @@ def _addSubDict(root,data):
         if type(data[key]) in (list,):
             _addSubList(root,key,data[key])
             continue
-        ET.SubElement(root,key).text=str(data[key])
+        ET.SubElement(root,str(key)).text=str(data[key])
 
 
 def _jsontoxml(dictionary,rootName="root"):


### PR DESCRIPTION
' TypeError: cannot serialize 1 (type int) ' caused due to the interger key of the XML Tag.
Fixed the error by converting the key into string.